### PR TITLE
Basic support for paging on Windows

### DIFF
--- a/Cargo.lock
+++ b/Cargo.lock
@@ -4,4 +4,4 @@ version = 4
 
 [[package]]
 name = "lessify"
-version = "0.4.0"
+version = "0.5.0"

--- a/Cargo.toml
+++ b/Cargo.toml
@@ -1,6 +1,6 @@
 [package]
 name = "lessify"
-version = "0.4.0"
+version = "0.5.0"
 edition = "2024"
 authors = ["Quentin Richert <noreply@richert.co>"]
 description = "Output text through a pager."

--- a/src/lib.rs
+++ b/src/lib.rs
@@ -73,10 +73,12 @@ impl Pager {
     /// print to stdout.
     pub fn page_or_print(content: &str) {
         if Self::page(content).is_err() {
+            let mut stdout = std::io::stdout();
+            // Using write! instead of print! fixes a panic in some circumstances.
             if content.ends_with('\n') {
-                print!("{content}");
+                let _ = write!(stdout, "{content}");
             } else {
-                println!("{content}");
+                let _ = writeln!(stdout, "{content}");
             }
         }
     }

--- a/src/lib.rs
+++ b/src/lib.rs
@@ -25,6 +25,19 @@
 //! // Same as `page_or_print()`.
 //! "very long text".output_paged();
 //! ```
+//!
+//! # Windows Notes
+//!
+//! The default pager on Windows is set to `more.com`. Unfortunately,
+//! at the time of writing `more` is legacy software which does not
+//! understand multi-byte characters. This leads to mojibake.
+//!
+//! Therefore, when using this crate on Windows, it is advisable to
+//! restrict what you print to the ASCII character set.
+//!
+//! Possible alternative solutions include:
+//! - Reading the active console codepage and converting the output.
+//! - Setting the console codepage, if this is appropriate.
 
 use std::env;
 use std::fmt;
@@ -37,9 +50,17 @@ use std::sync::LazyLock;
 /// The logic is as follows:
 ///
 /// 1. Look for `PAGER` in the environment.
-/// 2. If not set, default to `less`.
-pub static PAGER: LazyLock<String> =
-    LazyLock::new(|| env::var("PAGER").unwrap_or_else(|_| String::from("less")));
+/// 2. If not set, default to `less` on Unix or `more.com` on Windows.
+pub static PAGER: LazyLock<String> = LazyLock::new(|| {
+    env::var("PAGER").unwrap_or_else(|_| {
+        if cfg!(windows) {
+            #[cfg(not(tarpaulin_include))]
+            String::from("more.com")
+        } else {
+            String::from("less")
+        }
+    })
+});
 
 /// Output text through a pager.
 pub struct Pager;
@@ -63,7 +84,7 @@ impl Pager {
     /// Try to use default pager to output `content`.
     ///
     /// The pager is read from the `PAGER` environment variable, or
-    /// defaults to `less`.
+    /// defaults to `less` on Unix or `more.com` on Windows.
     ///
     /// # Errors
     ///


### PR DESCRIPTION
Hello!

This patchset uses the `more` utility to support paging out of the box on Windows, and fixes a panic that happens in at least the mingw build when you quit the pager early.

More is present as `C:\Windows\System32\more.com` on most installs... but there's a catch. It doesn't support UTF-8, even though Windows terminal does, and perhaps not even Windows wide characters. It works fine when you restrict yourself to the basic ASCII character set, or if you care to go to the trouble of reading out the active console codepage and converting your output string.

So while this is _a_ solution for Windows, it's not brilliant quality due to the limitations of that platform. I won't mind if you decide to not accept it, or to keep it behind a feature-flag.